### PR TITLE
Update Google resources to support latest version of provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,14 +52,14 @@ resource "google_kms_key_ring" "default" {
 
 resource "google_kms_key_ring_iam_binding" "default" {
   for_each    = var.iam
-  key_ring_id = local.keyring.self_link
+  key_ring_id = local.keyring.id
   role        = each.key
   members     = each.value
 }
 
 resource "google_kms_crypto_key" "default" {
   for_each        = var.keys
-  key_ring        = local.keyring.self_link
+  key_ring        = local.keyring.id
   name            = each.key
   rotation_period = try(each.value.rotation_period, null)
   labels          = try(each.value.labels, null)
@@ -82,6 +82,6 @@ resource "google_kms_crypto_key_iam_binding" "default" {
     "${binding.key}.${binding.role}" => binding
   }
   role          = each.value.role
-  crypto_key_id = google_kms_crypto_key.default[each.value.key].self_link
+  crypto_key_id = google_kms_crypto_key.default[each.value.key].id
   members       = each.value.members
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,7 +40,7 @@ output "name" {
 
 output "self_link" {
   description = "Keyring self link."
-  value       = local.keyring.self_link
+  value       = local.keyring.id
   depends_on = [
     google_kms_key_ring_iam_binding.default
   ]
@@ -58,7 +58,7 @@ output "key_self_links" {
   description = "Key self links."
   value = {
     for name, resource in google_kms_crypto_key.default :
-    name => resource.self_link
+    name => resource.id
   }
   depends_on = [
     google_kms_crypto_key_iam_binding.default

--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,15 @@
 
 terraform {
   required_version = ">= 0.12.6"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.0"
+    }
+  }
 }


### PR DESCRIPTION
These changes are necessary for using this module with versions >=4.0.0 of the Google terraform provider. 