### PR TITLE
Fixing terraform required version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.0.0"
 
   required_providers {
     google = {


### PR DESCRIPTION
ensures users use at least Terraform v1.0.0 in combination with the Google provider >= 4.0.0