### PR TITLE
Sre 3191 dapper nft bridge kms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "google_kms_crypto_key" "default" {
     }
   }
   lifecycle {
-    prevent_destroy = try(each.value.prevent_destroy, false)
+    prevent_destroy = each.value.prevent_destroy || false
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -58,12 +58,13 @@ resource "google_kms_key_ring_iam_binding" "default" {
 }
 
 resource "google_kms_crypto_key" "default" {
-  for_each        = var.keys
-  key_ring        = local.keyring.id
-  name            = each.key
-  rotation_period = try(each.value.rotation_period, null)
-  labels          = try(each.value.labels, null)
-  purpose         = try(local.key_purpose[each.key].purpose, null)
+  for_each                   = var.keys
+  key_ring                   = local.keyring.id
+  name                       = each.key
+  rotation_period            = try(each.value.rotation_period, null)
+  labels                     = try(each.value.labels, null)
+  destroy_scheduled_duration = try(each.value.destroy_scheduled_duration, null)
+  purpose                    = try(local.key_purpose[each.key].purpose, null)
   dynamic "version_template" {
     for_each = local.key_purpose[each.key].version_template == null ? [] : [""]
     content {
@@ -71,9 +72,9 @@ resource "google_kms_crypto_key" "default" {
       protection_level = local.key_purpose[each.key].version_template.protection_level
     }
   }
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
+  lifecycle {
+    prevent_destroy = try(each.value.prevent_destroy, false)
+  }
 }
 
 resource "google_kms_crypto_key_iam_binding" "default" {

--- a/main.tf
+++ b/main.tf
@@ -72,9 +72,10 @@ resource "google_kms_crypto_key" "default" {
       protection_level = local.key_purpose[each.key].version_template.protection_level
     }
   }
-  #  lifecycle {
-  #    prevent_destroy = each.value.prevent_destroy || false
-  #  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_kms_crypto_key_iam_binding" "default" {

--- a/main.tf
+++ b/main.tf
@@ -72,9 +72,9 @@ resource "google_kms_crypto_key" "default" {
       protection_level = local.key_purpose[each.key].version_template.protection_level
     }
   }
-  lifecycle {
-    prevent_destroy = each.value.prevent_destroy || false
-  }
+  #  lifecycle {
+  #    prevent_destroy = each.value.prevent_destroy || false
+  #  }
 }
 
 resource "google_kms_crypto_key_iam_binding" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,6 @@ variable "keys" {
   type = map(object({
     rotation_period            = string
     labels                     = map(string)
-    prevent_destroy            = bool
     destroy_scheduled_duration = string
   }))
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,7 @@ variable "keyring_create" {
   default     = true
 }
 
+# The maximum value for destroy_scheduled_duration is 120 days (set to "120d")
 variable "keys" {
   description = "Key names and base attributes. Set attributes to null if not needed."
   type = map(object({

--- a/variables.tf
+++ b/variables.tf
@@ -72,8 +72,10 @@ variable "keyring_create" {
 variable "keys" {
   description = "Key names and base attributes. Set attributes to null if not needed."
   type = map(object({
-    rotation_period = string
-    labels          = map(string)
+    rotation_period            = string
+    labels                     = map(string)
+    prevent_destroy            = bool
+    destroy_scheduled_duration = string
   }))
   default = {}
 }


### PR DESCRIPTION
This PR accomplishes two important things for KMS keys

1. Enables the ability to define the `destroy_scheduled_duration` which is the amount of time that a KMS key will be retained by GCP after it has been deleted before it is fully deleted from GCPs system. This can only be set when the key is created. GCPs default is 24 hours, but it is in our best interest to set it to 120 days. 
2. It adds the lifecycle policy to prevent terraform from destroying KMS keys even by accident. This is further protection against accidentally deleting KMS keys.